### PR TITLE
refactor: remove hardcoded user ID check from push notification logic

### DIFF
--- a/scripts/sendPushNotifications.js
+++ b/scripts/sendPushNotifications.js
@@ -40,7 +40,6 @@ async function sendPushNotifications() {
 
     // Filter users who have an Expo push token in their metadata
     const usersWithTokens = users.filter(user =>
-        user.id === "cb5400a3-6dfe-49bf-9bb8-d02d81c204a1" &&
         user.metadata &&
         typeof user.metadata === 'object' &&
         user.metadata.expoPushToken


### PR DESCRIPTION
This pull request includes a small change to the `sendPushNotifications` script. The update removes a hardcoded user ID filter, allowing the function to process all users with valid Expo push tokens.