### PR TITLE
chore: add required npm packages for inactivity reminders workflow

### DIFF
--- a/.github/workflows/send-inactivity-reminders.yml
+++ b/.github/workflows/send-inactivity-reminders.yml
@@ -15,7 +15,9 @@ jobs:
         with:
           node-version: '16'
       - name: Install dependencies
-        run: npm install
+        run: |
+          npm install @supabase/supabase-js
+          npm install expo-server-sdk
       - name: Send inactivity reminders
         run: node scripts/sendInactivityReminders.js
         env:


### PR DESCRIPTION
This pull request updates the dependency installation process in the GitHub Actions workflow for sending inactivity reminders. The change ensures that two specific packages, `@supabase/supabase-js` and `expo-server-sdk`, are explicitly installed.

Dependency installation update:

* [`.github/workflows/send-inactivity-reminders.yml`](diffhunk://#diff-931875a51f1ed132b4d3e22d59f1e4956c11a2feebd10a4626c1240fced94241L18-R20): Modified the `Install dependencies` step to include the installation of `@supabase/supabase-js` and `expo-server-sdk` packages.